### PR TITLE
[JR-428] There should be space between text and links on website tips and activities pages

### DIFF
--- a/src/components/sectionitem/linkedsectionitem.jsx
+++ b/src/components/sectionitem/linkedsectionitem.jsx
@@ -42,7 +42,7 @@ const LinkedSectionItem = ({
                 </TxDiv>
             </Link>
             <div className="content-section-item-description">
-                {description || children}
+                {description || children} &nbsp;
                 <Link to={linkURL}>
                     {linkText}
                 </Link>

--- a/src/components/sectionitem/staticlinksectionitem.jsx
+++ b/src/components/sectionitem/staticlinksectionitem.jsx
@@ -47,7 +47,7 @@ const StaticLinkSectionItem = ({
                 </div>
             </a>
             <div className="content-section-item-description">
-                {description || children}
+                {description || children} &nbsp;
                 <a
                     href={linkURL}
                     rel="noopener noreferrer"


### PR DESCRIPTION
### Resolves

- Resolves  https://scratchfoundation.atlassian.net/browse/JR-428

### Proposed Changes

Creates space between text and link

### Reason for Changes

Visual fix & this was breaking translations.

Screenshot teach/activities:
<img width="836" alt="Screenshot 2023-05-16 at 10 06 40 AM" src="https://github.com/scratchfoundation/scratchjr-website/assets/12954243/4e537ab3-ee76-410b-a56c-2b18eebfc26b">

Screenshot learn/tips:
<img width="815" alt="Screenshot 2023-05-16 at 10 06 50 AM" src="https://github.com/scratchfoundation/scratchjr-website/assets/12954243/9f72b140-d706-4ef5-a753-4b50c45018fc">


