### PR TITLE
refactor: remove twitter timeline widget

### DIFF
--- a/src/views/index/index.jsx
+++ b/src/views/index/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {render} from 'react-dom';
-import {Timeline} from 'react-twitter-widgets';
 import NavBar from '../../components/navbar/navbar.jsx';
 import Footer from '../../components/footer/footer.jsx';
 import Carousel from '../../components/carousel/carousel.jsx';
@@ -94,20 +93,6 @@ const Index = () => {
                                 <div className="blue-button">Tweet @ScratchJr</div>
                             </a>
                         </div>
-                    </div>
-                    <div id="disscussion-tweets">
-                        <Timeline
-                            dataSource={{
-                                sourceType: 'profile',
-                                screenName: 'ScratchJr'
-                            }}
-                            options={{
-                                username: 'ScratchJr',
-                                width: '425',
-                                height: '250',
-                                chrome: 'noheader nofooter'
-                            }}
-                        />
                     </div>
                 </div>
             </div>

--- a/src/views/outreach/news.jsx
+++ b/src/views/outreach/news.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Timeline} from 'react-twitter-widgets';
 
 const NewsSection = () => (
     <div
@@ -19,20 +18,6 @@ const NewsSection = () => (
                     Tweet #ScratchJrFamily
                 </div>
             </a>
-        </div>
-        <div className="fd-news-feed">
-            <Timeline
-                dataSource={{
-                    sourceType: 'url',
-                    url: 'https://twitter.com/ScratchJr/timelines/1021452548371288064?ref_src=twsrc%5Etfw'
-                }}
-                options={{
-                    username: 'ScratchJr',
-                    width: '600',
-                    height: '800',
-                    chrome: 'noheader nofooter'
-                }}
-            />
         </div>
     </div>
 );


### PR DESCRIPTION
### Resolves

The twitter timeline widget stopped working.  Twitter updated the widgets API and deprecated some features this also made our current version of the react-twitter-widgets incompatible. We are unable to upgrade to more current versions of this library due to the version of react that we are using.

Per @chrisgarrity we've decided to remove the twitter timeline widget. 

The widget appears in 2 places. 
1. the home page .
2. the Family day news page.